### PR TITLE
Pre-launch readiness for parryai.app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,17 @@
 # CLAUDE.md - parry Marketing Website
 
-Marketing website for parry, an AI-powered mobile app for text message reply suggestions.
+Marketing website for parry, an AI-powered mobile app for text message reply suggestions. Operated by Anomaly Labs LLC (parry is a registered DBA).
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|------------|
-| Framework | Astro 5 (static output, zero JS) |
+| Framework | Astro 5 (static output, zero JS by default) |
 | Styling | Tailwind CSS v4 (CSS-based `@theme` config) |
 | Icons | `@phosphor-icons/core` via `<Icon>` component |
-| Fonts | Google Fonts: Sora (headings), Outfit (body) |
-| Hosting | Render (static site) |
-| Domain | parryai.app |
+| Fonts | Google Fonts: Fraunces (display serif), Geist (body sans-serif) |
+| Hosting | Render (auto-deploys on push to `main`) |
+| Domain | parryai.app (registered via Namecheap) |
 
 ## Commands
 
@@ -26,73 +26,92 @@ npm run preview     # Preview built site
 ```
 src/
 ├── layouts/
-│   └── BaseLayout.astro        # Shared <html>, fonts, meta, bg gradient
+│   └── BaseLayout.astro        # Shared <html>, fonts, meta, Organization JSON-LD
 ├── pages/
-│   ├── index.astro             # Landing page
+│   ├── index.astro             # Landing page (passes MobileApplication JSON-LD)
 │   ├── privacy.astro           # Privacy policy
 │   ├── terms.astro             # Terms of service
-│   └── 404.astro               # Custom 404 page
+│   └── 404.astro               # Custom 404 page (no canonicalPath)
 ├── components/
-│   ├── Header.astro            # Logo + nav
+│   ├── Header.astro            # Logo only (no nav CTA)
 │   ├── Footer.astro            # Links, copyright, support email
-│   ├── Hero.astro              # Headline, CTA, phone mockup
+│   ├── Hero.astro              # Headline, CTA, phone mockup, sentinel
 │   ├── HowItWorks.astro        # 3-step section
 │   ├── Features.astro          # Feature cards
 │   ├── SocialProof.astro       # Claude AI attribution badge
-│   ├── PainPoint.astro         # "Sound familiar?" empathy/pain-point section
-│   ├── TonesShowcase.astro     # Scenario cards showing tones in action
+│   ├── PainPoint.astro         # "Sound familiar?" empathy section
+│   ├── TonesShowcase.astro     # WAI-ARIA tabs showing tones in action
 │   ├── Privacy.astro           # Trust/privacy section
-│   ├── DownloadCTA.astro       # App Store/Play Store badges
-│   ├── FAQ.astro               # <details>/<summary> accordion
-│   ├── PhoneMockup.astro       # CSS phone frame with mock app UI
+│   ├── DownloadCTA.astro       # App Store badge
+│   ├── FAQ.astro               # <details>/<summary> + FAQPage JSON-LD
+│   ├── MobileDownloadBar.astro # Fixed bottom bar, IntersectionObserver-gated
+│   ├── PhoneMockup.astro       # CSS phone frame with placeholder app UI
 │   └── Icon.astro              # Phosphor icon loader (build-time SVG)
 ├── styles/
 │   └── global.css              # Tailwind @theme tokens, utilities, animations
 public/
-├── favicon.svg
-├── favicon.ico
-├── og-image.svg                # Placeholder (needs real PNG)
+├── favicon.svg / favicon.ico / apple-touch-icon.png
+├── og-image.png                # 1200×630
 ├── app-store-badge.svg         # Placeholder (not official Apple asset)
 ├── google-play-badge.svg       # Placeholder (not official Google asset)
+├── brand/                      # Wordmark and logo variants
 ├── llms.txt                    # AI crawler discoverability
-└── robots.txt
+└── robots.txt                  # AI crawler allowlist + scraper blocklist
 ```
 
-## Design System
+## Design System — Editorial Dark
 
-Design tokens originate from the mobile app at `~/Documents/parry/src/theme/`.
-Full mobile app docs at `~/Documents/parry/docs/` (start with `docs/00-OVERVIEW.md`).
+Independent design system. Diverged from the mobile app's glassmorphism in the PR #7 redesign; tokens now originate directly in `src/styles/global.css`, not from the mobile app's theme files.
 
-All color, font, and radius tokens are defined in `src/styles/global.css` inside the
-`@theme {}` block and are usable as Tailwind utilities (e.g. `text-text-secondary`, `bg-surface`).
+Key tokens (all defined in `@theme {}` inside `global.css`, usable as Tailwind utilities):
 
-Web-specific notes:
-- **text-secondary** was bumped from the mobile app's `0.65` opacity to `0.72` for WCAG AA on dark backgrounds.
-- **glass-card** (PhoneMockup) includes `backdrop-filter: blur()`. Expensive on mobile.
-- **header-blur** (Header) uses a `::before` pseudo-element with `backdrop-filter: blur()` and a mask-image fade.
-- **glass-card-lite** (all other cards) has the same look but skips `backdrop-filter` for performance.
+- **Background:** `--color-bg-base: #161220` (warm plum-tinted near-black, solid — no gradient)
+- **Accent:** `--color-accent: #E8734A` (single coral accent; `--color-accent-text: #F39C7A` for body-text occurrences)
+- **Text:** `--color-text-primary` (white), `--color-text-secondary` (white 0.78), `--color-text-tertiary` (white 0.55)
+- **Hairlines:** `--color-hairline` (white 0.08) instead of card shadows
+- **Fonts:** `--font-display: Fraunces`, `--font-body: Geist`
+- **Type scale:** `--text-hero`, `--text-display`, `--text-section`, `--text-eyebrow` (clamp-based for fluid scaling)
+
+Surface primitives (utility classes in `global.css`):
+
+- `site-header` — fixed translucent header with hairline-bottom (no `backdrop-filter`)
+- `surface-elevated` — rare inset card surface
+- `hairline-top` / `hairline-bottom` — single-pixel dividers
+- `eyebrow` — small-caps section label
+- `btn-primary` — solid coral pill button
+- `hero-glow` — single low-intensity radial behind Hero
+- `prose-legal` — typography wrapper for `/privacy` and `/terms`
+- `font-display` — Fraunces with letter-spacing and optical sizing
 
 ## Conventions
 
 - All icons via `<Icon name="..." />`, never inline SVG.
-- Decorative icons: `text-warm-gold`. Interactive icons: `text-accent`.
-- Headings: `font-[var(--font-sora)]`. Body text uses Outfit (set on `<body>`).
+- Headings use `font-display`. Body text uses Geist (set on `<body>`).
 - Cross-page anchor links use absolute paths (`/#download`, not `#download`).
-- Legal pages (`/privacy`, `/terms`) use the `prose-legal` class for consistent typography.
+- Legal pages (`/privacy`, `/terms`) use the `prose-legal` class.
+- `BaseLayout` props: `title`, `description`, `canonicalPath?`, `jsonLd?`, `showMobileDownloadBar?`. Omit `canonicalPath` for the 404 page.
 
 ## Critical URLs
 
-The parry mobile app links to these from its settings screen:
-- `https://parryai.app/privacy` -- Privacy Policy
-- `https://parryai.app/terms` -- Terms of Service
+The parry mobile app currently links `https://parryai.app/privacy` from its AI consent modal (`AIConsentModal.tsx`). Once a Settings screen ships there, `/terms` will be linked too. **These routes MUST work and contain the correct legal text** — they are referenced from the App Store listing and the in-app consent flow.
 
-**These routes MUST work and contain the correct legal text.**
+## Legal entity
+
+- Operating entity: **Anomaly Labs LLC** (Washington state, formed April 2026)
+- DBA: **parry**
+- Legal pages (`privacy.astro`, `terms.astro`) use "Anomaly Labs LLC" for legal-claim contexts (operator, owner, indemnification, copyright) and keep "parry" for brand-voice references.
+
+## Structured data
+
+- `Organization` JSON-LD ships sitewide via `BaseLayout.astro` (legalName = Anomaly Labs LLC, name = parry).
+- `MobileApplication` JSON-LD ships on `/` via the `jsonLd` prop in `index.astro`.
+- `FAQPage` JSON-LD ships on `/` from `FAQ.astro`, sourced from the same `faqs` array.
 
 ## Gotchas
 
 - **Tailwind v4** uses CSS-based `@theme {}` in `global.css`, not a JS config file.
-- **Icon.astro** reads SVGs from `@phosphor-icons/core` at build time via `createRequire`.
-  Names are kebab-case (`shield-check`, `clipboard-text`). Verify names at phosphoricons.com.
-- **og:image** meta references `og-image.png` but only `og-image.svg` placeholder exists.
-- **Store badges** are placeholder SVGs, not official Apple/Google assets.
-- **canonicalPath** prop on BaseLayout is optional; omit it for the 404 page.
+- **Icon.astro** reads SVGs from `@phosphor-icons/core` at build time via `createRequire`. Names are kebab-case (`shield-check`, `clipboard-text`). Verify at phosphoricons.com.
+- **`apple-itunes-app`** meta in `BaseLayout.astro` uses the real App Store ID (`6761346279`). The banner only renders in mobile Safari for published apps, so it's inert until parry is live in the App Store.
+- **Store badges** are placeholder SVGs, not official Apple/Google assets. Tracked in issue #9.
+- **Phone mockup** uses placeholder content. Real screenshots tracked in issue #9.
+- **`canonicalPath`** is optional; omit it for the 404 page (and the JSON-LD `og:url` will also be omitted, which is correct behavior).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Marketing and landing page for [parry](https://parryai.app), an AI-powered mobil
 - **Astro 5** -- static HTML/CSS output, zero client-side JavaScript
 - **Tailwind CSS v4** -- CSS-based `@theme` configuration
 - **Phosphor Icons** -- light-weight SVGs loaded at build time
-- **Cloudflare Pages** -- hosting (planned)
+- **Render** -- hosting; auto-deploys on push to `main`
 
 ## Getting Started
 
@@ -42,4 +42,4 @@ public/             # Static assets (favicons, badges, robots.txt, llms.txt)
 
 ## Design
 
-The visual design matches the parry mobile app, using the same color palette, glassmorphism cards, and typography. Design tokens originate from the mobile app's theme files in the sibling repo at `~/Documents/parry/`.
+Editorial-dark visual system, intentionally diverged from the mobile app's glassmorphism look. Solid plum-tinted near-black background (`#161220`), Fraunces display serif paired with Geist body sans-serif, single coral accent (`#E8734A`), and hairline-bordered surfaces instead of frosted cards. All tokens live in `src/styles/global.css` inside Tailwind v4's `@theme {}` block.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,11 +2,11 @@
 
 > AI-powered reply suggestions for text messages. A mobile app that helps you craft the perfect response.
 
-parry lets you paste a text message, pick a tone, and get three ready-to-send replies in seconds. Available on iOS and Android.
+parry lets you paste a text message, pick a tone, and get four ready-to-send replies in seconds. Currently launching on iOS; Android is on the roadmap.
 
 ## Features
 - 5 built-in tones: Casual, Professional, Supportive, Witty, Assertive
-- Custom tone presets (Pro)
+- 1 custom tone preset on the free tier; up to 4 with Pro
 - Voice input with transcription
 - Image and screenshot input (Pro)
 
@@ -17,8 +17,12 @@ parry lets you paste a text message, pick a tone, and get three ready-to-send re
 - Your data is never used to train AI models
 
 ## Pricing
-- Free: reply generations every day, no account needed
-- Pro: monthly or annual subscription — more generations, custom tones, priority processing
+- Free: 5 generations per day, 1 custom tone, no account required
+- Pro (monthly or annual): 200 generations per day, up to 4 custom tones, priority processing
+
+## Company
+- Operator: Anomaly Labs LLC (Washington state, USA), operating parry as a registered DBA
+- Founded: April 2026
 
 ## Pages
 - [Home](https://parryai.app): Landing page with features and download links

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -4,11 +4,11 @@ import Icon from './Icon.astro';
 const faqs = [
   {
     question: "Is parry free?",
-    answer: "Yes. parry is free to download and use every day, no account needed. If you want more replies and custom tones, you can upgrade to parry Pro."
+    answer: "Yes. The free tier gives you five generations per day and one custom tone, no account needed. If you want more, you can upgrade to parry Pro."
   },
   {
     question: "How much does parry Pro cost?",
-    answer: "parry Pro is available as a monthly or annual subscription. You can see current pricing in the app. Pro gives you more daily replies, custom tone presets, and priority processing."
+    answer: "parry Pro is available as a monthly or annual subscription — you can see current pricing in the app. Pro gives you 200 generations per day, up to four custom tones, and priority processing."
   },
   {
     question: "How does it work?",
@@ -20,7 +20,7 @@ const faqs = [
   },
   {
     question: "What tones are available?",
-    answer: "parry includes five built-in tones: Casual, Professional, Supportive, Witty, and Assertive. Pro subscribers can also create custom tone presets (like \"the rizler\" or \"corporate robot\") that match their unique communication style."
+    answer: "parry includes five built-in tones: Casual, Professional, Supportive, Witty, and Assertive. Everyone can also create one custom tone preset (like \"the rizler\" or \"corporate robot\") that matches their style. Pro subscribers can create up to four custom tones."
   },
   {
     question: "What makes parry different from ChatGPT?",

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -39,6 +39,19 @@ const faqs = [
     answer: "No. Your messages are processed in real-time and immediately discarded. Nothing is saved, logged, or backed up. We couldn't look at your messages even if we wanted to."
   }
 ];
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": faqs.map((f) => ({
+    "@type": "Question",
+    "name": f.question,
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": f.answer.replace(/<[^>]+>/g, "")
+    }
+  }))
+};
 ---
 
 <section class="px-6 py-24 md:px-10 md:py-32 lg:px-14">
@@ -69,3 +82,5 @@ const faqs = [
     </div>
   </div>
 </section>
+
+<script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl px-6 py-12 md:px-10 lg:px-14">
     <div class="flex flex-col items-center gap-6 md:flex-row md:justify-between">
       <p class="text-sm text-text-tertiary">
-        &copy; 2026 parry
+        &copy; 2026 Anomaly Labs LLC
       </p>
 
       <nav aria-label="Footer" class="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-sm">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,7 +2,7 @@
 import PhoneMockup from './PhoneMockup.astro';
 ---
 
-<section class="relative overflow-hidden px-6 pt-16 pb-20 md:px-10 md:pt-24 md:pb-28 lg:px-14 lg:pt-12 lg:pb-16">
+<section class="relative overflow-hidden px-6 pt-8 pb-12 md:px-10 md:pt-24 md:pb-28 lg:px-14 lg:pt-12 lg:pb-16">
   <div class="hero-glow" aria-hidden="true"></div>
 
   <div class="relative mx-auto grid max-w-7xl items-center gap-12 lg:grid-cols-[1.1fr_1fr] lg:gap-16">
@@ -38,4 +38,7 @@ import PhoneMockup from './PhoneMockup.astro';
       <PhoneMockup />
     </div>
   </div>
+
+  {/* Sentinel for the sticky mobile download bar — see MobileDownloadBar.astro. */}
+  <div id="hero-sentinel" aria-hidden="true" class="absolute bottom-0 left-0 h-px w-px"></div>
 </section>

--- a/src/components/MobileDownloadBar.astro
+++ b/src/components/MobileDownloadBar.astro
@@ -1,0 +1,55 @@
+<div id="mobile-download-bar" class="mobile-download-bar" aria-hidden="true">
+  <a href="/#download" class="flex items-center justify-between gap-4 px-5 py-3" aria-label="Download parry on the App Store">
+    <span class="text-sm font-medium text-text-primary">Free on iOS</span>
+    <img src="/app-store-badge.svg" alt="" width="120" height="40" class="h-10 w-auto" />
+  </a>
+</div>
+
+<style>
+  .mobile-download-bar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 40;
+    background: rgba(14, 11, 17, 0.92);
+    border-top: 1px solid var(--color-hairline);
+    backdrop-filter: blur(10px);
+    transform: translateY(100%);
+    transition: transform 0.3s ease;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .mobile-download-bar.is-visible {
+    transform: translateY(0);
+  }
+
+  @media (min-width: 768px) {
+    .mobile-download-bar {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mobile-download-bar {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  const bar = document.getElementById('mobile-download-bar');
+  const sentinel = document.getElementById('hero-sentinel');
+
+  if (bar && sentinel && 'IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const past = !entry.isIntersecting && entry.boundingClientRect.top < 0;
+        bar.classList.toggle('is-visible', past);
+        bar.setAttribute('aria-hidden', past ? 'false' : 'true');
+      },
+      { threshold: 0 }
+    );
+    observer.observe(sentinel);
+  }
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,6 +12,22 @@ interface Props {
 
 const { title, description, canonicalPath, jsonLd } = Astro.props;
 const canonicalUrl = canonicalPath !== undefined ? `https://parryai.app${canonicalPath}` : null;
+
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "parry",
+  "legalName": "Anomaly Labs LLC",
+  "url": "https://parryai.app",
+  "email": "support@parryai.app",
+  "logo": "https://parryai.app/brand/parry-wordmark-white.svg",
+  "foundingDate": "2026-04-14",
+  "address": {
+    "@type": "PostalAddress",
+    "addressRegion": "WA",
+    "addressCountry": "US"
+  }
+};
 ---
 
 <html lang="en">
@@ -21,6 +37,11 @@ const canonicalUrl = canonicalPath !== undefined ? `https://parryai.app${canonic
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#161220" />
+
+    {/* Apple smart app banner. Inert until parry is live in the App Store —
+        mobile Safari only renders the banner for published apps. Safe to
+        ship now. */}
+    <meta name="apple-itunes-app" content="app-id=6761346279, app-argument=parry://" />
 
     <title>{title}</title>
 
@@ -53,6 +74,7 @@ const canonicalUrl = canonicalPath !== undefined ? `https://parryai.app${canonic
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content="https://parryai.app/og-image.png" />
 
+    <script type="application/ld+json" set:html={JSON.stringify(organizationJsonLd)} />
     {jsonLd && (
       <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
     )}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,15 +2,17 @@
 import '../styles/global.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import MobileDownloadBar from '../components/MobileDownloadBar.astro';
 
 interface Props {
   title: string;
   description: string;
   canonicalPath?: string;
   jsonLd?: Record<string, unknown>;
+  showMobileDownloadBar?: boolean;
 }
 
-const { title, description, canonicalPath, jsonLd } = Astro.props;
+const { title, description, canonicalPath, jsonLd, showMobileDownloadBar = false } = Astro.props;
 const canonicalUrl = canonicalPath !== undefined ? `https://parryai.app${canonicalPath}` : null;
 
 const organizationJsonLd = {
@@ -87,5 +89,6 @@ const organizationJsonLd = {
       <slot />
     </main>
     <Footer />
+    {showMobileDownloadBar && <MobileDownloadBar />}
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,8 +37,8 @@ const jsonLd = {
   title="parry — Never Overthink a Message Again"
   description="parry gives you the right reply for any message. Paste a message, pick a tone, get four ready-to-send responses. Free on iOS."
   canonicalPath=""
-
   jsonLd={jsonLd}
+  showMobileDownloadBar
 >
   <Hero />
   <SocialProof />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const jsonLd = {
   },
   "author": {
     "@type": "Organization",
-    "name": "parry",
+    "name": "Anomaly Labs LLC",
     "url": "https://parryai.app"
   }
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,9 @@ const jsonLd = {
     "@type": "Organization",
     "name": "Anomaly Labs LLC",
     "url": "https://parryai.app"
-  }
+  },
+  "inLanguage": "en-US",
+  "softwareVersion": "1.0.0"
 };
 ---
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,8 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-// TODO(issue #8): update entity name when LLC is formed.
-// Frontmatter JS comment — does NOT ship to client. Don't move this back to an HTML
-// comment; it would expose pre-LLC status on the privacy page (View Source visibility).
 ---
 <BaseLayout
   title="Privacy Policy — parry"
@@ -13,11 +10,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="prose-legal mx-auto max-w-3xl">
       <p class="eyebrow mb-5">Legal</p>
       <h1 class="font-display mb-3 text-4xl font-semibold tracking-tight md:text-5xl" style="letter-spacing: -0.025em;">Privacy Policy</h1>
-      <p class="mb-12 text-sm text-text-tertiary">Last updated: March 2026</p>
+      <p class="mb-12 text-sm text-text-tertiary">Last updated: May 2026</p>
 
       <h2>Introduction</h2>
       <p>
-        parry ("we", "our", "us") operates the parry mobile application. This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our app.
+        Anomaly Labs LLC ("we", "our", "us"), operating as parry, provides the parry mobile application. This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our app.
       </p>
 
       <h2>Information Collection and Use</h2>
@@ -144,7 +141,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         Email: <a href="mailto:support@parryai.app">support@parryai.app</a>
       </p>
 
-      <p class="mt-8 text-sm text-text-tertiary">&copy; 2026 parry. All rights reserved.</p>
+      <p class="mt-8 text-sm text-text-tertiary">&copy; 2026 Anomaly Labs LLC. All rights reserved.</p>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,8 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-// TODO(issue #8): update entity name when LLC is formed.
-// Frontmatter JS comment — does NOT ship to client. Don't move this back to an HTML
-// comment; it would expose pre-LLC status on the terms page (View Source visibility).
 ---
 <BaseLayout
   title="Terms of Service — parry"
@@ -13,11 +10,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="prose-legal mx-auto max-w-3xl">
       <p class="eyebrow mb-5">Legal</p>
       <h1 class="font-display mb-3 text-4xl font-semibold tracking-tight md:text-5xl" style="letter-spacing: -0.025em;">Terms of Service</h1>
-      <p class="mb-12 text-sm text-text-tertiary">Last updated: March 2026</p>
+      <p class="mb-12 text-sm text-text-tertiary">Last updated: May 2026</p>
 
       <h2>1. Acceptance of Terms</h2>
       <p>
-        By downloading, installing, or using parry ("the App" or "the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use the Service.
+        These Terms of Service ("Terms") are an agreement between you and Anomaly Labs LLC ("we", "our", "us"), the operator of parry. By downloading, installing, or using parry ("the App" or "the Service"), you agree to be bound by these Terms. If you do not agree to these Terms, do not use the Service.
       </p>
 
       <h2>2. Description of Service</h2>
@@ -84,7 +81,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
       <h2>8. Intellectual Property</h2>
       <ul>
-        <li>The app and its content are owned by parry</li>
+        <li>The app and its content are owned by Anomaly Labs LLC</li>
         <li>AI-generated responses are provided for your personal use</li>
         <li>You may not resell or redistribute the app or its outputs</li>
       </ul>
@@ -112,15 +109,15 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
       <h2>11. Limitation of Liability</h2>
       <p>
-        TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL PARRY, ITS OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR IN CONNECTION WITH YOUR ACCESS TO OR USE OF (OR INABILITY TO ACCESS OR USE) THE SERVICE.
+        TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL ANOMALY LABS LLC, ITS OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR IN CONNECTION WITH YOUR ACCESS TO OR USE OF (OR INABILITY TO ACCESS OR USE) THE SERVICE.
       </p>
       <p>
-        TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE TOTAL LIABILITY OF PARRY FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THESE TERMS OR THE SERVICE SHALL NOT EXCEED THE GREATER OF (A) ONE HUNDRED U.S. DOLLARS ($100) OR (B) THE TOTAL AMOUNT YOU PAID TO PARRY IN THE TWELVE (12) MONTHS PRECEDING THE EVENT GIVING RISE TO THE CLAIM.
+        TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE TOTAL LIABILITY OF ANOMALY LABS LLC FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THESE TERMS OR THE SERVICE SHALL NOT EXCEED THE GREATER OF (A) ONE HUNDRED U.S. DOLLARS ($100) OR (B) THE TOTAL AMOUNT YOU PAID TO ANOMALY LABS LLC IN THE TWELVE (12) MONTHS PRECEDING THE EVENT GIVING RISE TO THE CLAIM.
       </p>
 
       <h2>12. Indemnification</h2>
       <p>
-        You agree to indemnify, defend, and hold harmless parry and its officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of AI-generated content; (b) your violation of these Terms; or (c) your violation of any rights of a third party.
+        You agree to indemnify, defend, and hold harmless Anomaly Labs LLC and its officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of AI-generated content; (b) your violation of these Terms; or (c) your violation of any rights of a third party.
       </p>
 
       <h2>13. Dispute Resolution</h2>
@@ -136,7 +133,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
       <h3>Class Action Waiver</h3>
       <p>
-        YOU AND PARRY AGREE THAT EACH MAY BRING CLAIMS AGAINST THE OTHER ONLY IN YOUR OR ITS INDIVIDUAL CAPACITY, AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS, CONSOLIDATED, OR REPRESENTATIVE PROCEEDING. THE ARBITRATOR MAY NOT CONSOLIDATE MORE THAN ONE PERSON'S CLAIMS AND MAY NOT OTHERWISE PRESIDE OVER ANY FORM OF A CLASS OR REPRESENTATIVE PROCEEDING.
+        YOU AND ANOMALY LABS LLC AGREE THAT EACH MAY BRING CLAIMS AGAINST THE OTHER ONLY IN YOUR OR ITS INDIVIDUAL CAPACITY, AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS, CONSOLIDATED, OR REPRESENTATIVE PROCEEDING. THE ARBITRATOR MAY NOT CONSOLIDATE MORE THAN ONE PERSON'S CLAIMS AND MAY NOT OTHERWISE PRESIDE OVER ANY FORM OF A CLASS OR REPRESENTATIVE PROCEEDING.
       </p>
 
       <h3>Opt-Out</h3>
@@ -169,7 +166,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         If any provision of these Terms is found to be unenforceable or invalid by a court of competent jurisdiction, that provision shall be limited or eliminated to the minimum extent necessary, and the remaining provisions shall remain in full force and effect.
       </p>
       <p>
-        These Terms, together with the <a href="/privacy">Privacy Policy</a>, constitute the entire agreement between you and parry regarding your use of the Service and supersede all prior agreements and understandings.
+        These Terms, together with the <a href="/privacy">Privacy Policy</a>, constitute the entire agreement between you and Anomaly Labs LLC regarding your use of the Service and supersede all prior agreements and understandings.
       </p>
 
       <h2>18. Governing Law</h2>
@@ -183,7 +180,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         Email: <a href="mailto:support@parryai.app">support@parryai.app</a>
       </p>
 
-      <p class="mt-8 text-sm text-text-tertiary">&copy; 2026 parry. All rights reserved.</p>
+      <p class="mt-8 text-sm text-text-tertiary">&copy; 2026 Anomaly Labs LLC. All rights reserved.</p>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
A bundle of small polish items to get the site launch-ready. Nothing fancy — mostly catching the website up to where the business and product actually are.

**Legal entity name.** Anomaly Labs LLC was officially formed back in April, so the legal pages now name the LLC wherever they make legal claims (operator, copyright, indemnification, etc.). Brand voice in body copy still says "parry" — that's the DBA, and the pattern reads the way you'd expect.

**SEO and structured data.** Added the Apple smart-app-banner meta with the real App Store ID, a sitewide Organization JSON-LD, and FAQPage JSON-LD on the homepage. All the hygiene that helps Google and AI assistants understand who we are.

**Mobile UX.** New sticky App Store CTA at the bottom of the screen on phones, hidden until you scroll past the Hero. Plus a small Hero padding fix so the CTA actually fits above the fold on iPhone SE.

**Tier-accurate copy.** The FAQ and `llms.txt` were vague about Free vs Pro. They now say the actual numbers (5 generations/day + 1 custom tone on Free; 200 generations/day + up to 4 custom tones on Pro).

**Docs cleanup.** README and CLAUDE.md were stale — still talked about glassmorphism and Sora/Outfit fonts from before the editorial-dark redesign. They now match reality.

Lighthouse and a cross-browser smoke test still to run once this deploys to Render.

Closes #8.